### PR TITLE
feat: add option to attach variable set to parent project

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [tfe_project_variable_set.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/project_variable_set) | resource |
 | [tfe_variable.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable) | resource |
 | [tfe_variable_set.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable_set) | resource |
 
@@ -34,6 +35,7 @@ No modules.
 | <a name="input_description"></a> [description](#input\_description) | Description of the variable set. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the variable set. | `string` | n/a | yes |
 | <a name="input_variables"></a> [variables](#input\_variables) | Map of variables. | <pre>map(object({<br/>    category    = string<br/>    description = optional(string, null)<br/>    hcl         = optional(bool, false)<br/>    sensitive   = optional(bool, false)<br/>    value       = string<br/>  }))</pre> | n/a | yes |
+| <a name="input_attach_to_project"></a> [attach\_to\_project](#input\_attach\_to\_project) | Whether to attach the variable set to the parent project if 'parent\_project\_id' is set. | `bool` | `true` | no |
 | <a name="input_global"></a> [global](#input\_global) | Whether the variable set applies to all workspaces in the organization. | `bool` | `false` | no |
 | <a name="input_organization"></a> [organization](#input\_organization) | Name of the organization. If omitted, organization must be defined in the provider config. | `string` | `null` | no |
 | <a name="input_parent_project_id"></a> [parent\_project\_id](#input\_parent\_project\_id) | ID of the project that should own the variable set. If set, then var.global must be false. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,13 @@ resource "tfe_variable_set" "default" {
   priority          = var.priority
 }
 
+resource "tfe_project_variable_set" "default" {
+  count = var.attach_to_project && var.parent_project_id != null ? 1 : 0
+
+  project_id      = var.parent_project_id
+  variable_set_id = tfe_variable_set.default.id
+}
+
 resource "tfe_variable" "default" {
   for_each = var.variables
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,10 @@
+variable "attach_to_project" {
+  type        = bool
+  default     = true
+  description = "Whether to attach the variable set to the parent project if 'parent_project_id' is set."
+  nullable    = false
+}
+
 variable "description" {
   type        = string
   description = "Description of the variable set."


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Adds a tfe_project_variable_set resource to automatically attach the variable set to the parent project when parent_project_id is specified.

A new attach_to_project variable (default true) controls this behaviour, allowing users to opt out if they only want the project to own the variable set without attaching it.
